### PR TITLE
docs: Fix Dependecies map example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// create dependencies for k6 version v0.52.0
-	deps := k6provider.Dependencies{"k6", "=v0.52.0"}
+	deps := k6provider.Dependencies{"k6": "=v0.52.0"}
 
 	// obtain binary from the build service
 	k6binary, err := provider.GetBinary(context.TODO(), deps)

--- a/provider.go
+++ b/provider.go
@@ -98,7 +98,7 @@ type Config struct {
 }
 
 // Dependencies defines a group of dependencies with their version constrains
-// For example, {"k6": "*", "k6/x/sql", ">v0.4.0"}
+// For example, {"k6": "*", "k6/x/sql": ">v0.4.0"}
 type Dependencies map[string]string
 
 // Provider implements an interface for providing custom k6 binaries


### PR DESCRIPTION
Some `Dependencies` (a `map[string]string`) examples was written with `,` between the key and the value