### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/k6-core


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning `@grafana/k6-core` as owner of all files.