### PR TITLE
Add structured logging support

### DIFF
--- a/download.go
+++ b/download.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -52,10 +53,11 @@ type downloader struct {
 	headers  map[string]string
 	retries  int
 	backoff  time.Duration
+	logger   *slog.Logger
 }
 
 // newDownloader returns a new Downloader
-func newDownloader(config DownloadConfig) (*downloader, error) {
+func newDownloader(config DownloadConfig, logger *slog.Logger) (*downloader, error) {
 	httpClient := http.DefaultClient
 
 	proxyURL := config.ProxyURL
@@ -81,7 +83,6 @@ func newDownloader(config DownloadConfig) (*downloader, error) {
 	if downloadAuthType == "" {
 		downloadAuthType = "Bearer"
 	}
-
 	return &downloader{
 		client:   httpClient,
 		auth:     downloadAuth,
@@ -89,6 +90,7 @@ func newDownloader(config DownloadConfig) (*downloader, error) {
 		headers:  config.Headers,
 		retries:  config.Retries,
 		backoff:  config.Backoff,
+		logger:   logger,
 	}, nil
 }
 
@@ -144,6 +146,11 @@ func (d *downloader) download(ctx context.Context, from string, path string, che
 			break
 		}
 
+		d.logger.Debug("Download retry",
+			"retries_left", retries,
+			"backoff", backoff,
+			"error", err,
+		)
 		time.Sleep(backoff)
 
 		// increase backoff exponentially for next retry

--- a/provider.go
+++ b/provider.go
@@ -8,6 +8,8 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -110,6 +112,7 @@ type Provider struct {
 	buildSrv   *buildClient
 	platform   string
 	pruner     *Pruner
+	logger     *slog.Logger
 }
 
 // NewDefaultProvider returns a Provider with default settings
@@ -122,6 +125,16 @@ func NewDefaultProvider() (*Provider, error) {
 
 // NewProvider returns a [Provider] with the given Config
 func NewProvider(config Config) (*Provider, error) {
+	return NewProviderWithLogger(config, nil)
+}
+
+// NewProviderWithLogger returns a [Provider] with the given Config and logger.
+// If logger is nil, a discard logger is used.
+func NewProviderWithLogger(config Config, logger *slog.Logger) (*Provider, error) {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
 	var err error
 
 	// try first deprecated BinDir
@@ -183,10 +196,12 @@ func NewProvider(config Config) (*Provider, error) {
 		pruneInterval = defaultPruneInterval
 	}
 
-	downloader, err := newDownloader(config.DownloadConfig)
+	downloader, err := newDownloader(config.DownloadConfig, logger)
 	if err != nil {
 		return nil, NewWrappedError(ErrConfig, err)
 	}
+
+	pruner := NewPrunerWithLogger(binDir, cacheSize, pruneInterval, logger)
 
 	return &Provider{
 		client:     httpClient,
@@ -194,7 +209,8 @@ func NewProvider(config Config) (*Provider, error) {
 		binDir:     binDir,
 		buildSrv:   buildSrv,
 		platform:   platform,
-		pruner:     NewPruner(binDir, cacheSize, pruneInterval),
+		pruner:     pruner,
+		logger:     logger,
 	}, nil
 }
 
@@ -221,6 +237,10 @@ func (p *Provider) GetArtifact(
 ) (Artifact, error) {
 	k6Constrains, buildDeps := buildDeps(deps)
 
+	p.logger.Debug("Resolving k6 artifact",
+		"deps", deps,
+		"platform", p.platform,
+	)
 	artifact, err := p.buildSrv.Build(ctx, p.platform, k6Constrains, buildDeps)
 	if err != nil {
 		if !errors.Is(err, ErrInvalidParameters) {
@@ -248,13 +268,20 @@ func (p *Provider) GetArtifact(
 		}
 		checksum = fmt.Sprintf("%x", decoded)
 	}
-	return Artifact{
+
+	resolved := Artifact{
 		ID:           artifact.ID,
 		URL:          artifact.URL,
 		Dependencies: artifact.Dependencies,
 		Platform:     artifact.Platform,
 		Checksum:     checksum,
-	}, nil
+	}
+	p.logger.Debug("Artifact resolved",
+		"artifact_id", resolved.ID,
+		"deps", resolved.Dependencies,
+		"url", resolved.URL,
+	)
+	return resolved, nil
 }
 
 // GetBinary returns a custom k6 binary that satisfies the given a set of dependencies.
@@ -299,6 +326,11 @@ func (p *Provider) GetBinary(ctx context.Context, constrains Dependencies) (K6Bi
 
 	// binary already exists and is valid
 	if err == nil {
+		p.logger.Info("Using cached k6 binary",
+			"path", binPath,
+			"artifact_id", artifact.ID,
+			"deps", artifact.Dependencies,
+		)
 		go p.pruner.Touch(binPath)
 
 		return K6Binary{
@@ -314,11 +346,24 @@ func (p *Provider) GetBinary(ctx context.Context, constrains Dependencies) (K6Bi
 		return K6Binary{}, NewWrappedError(ErrBinary, err)
 	}
 
+	p.logger.Info("Downloading custom k6 binary",
+		"artifact_id", artifact.ID,
+		"deps", artifact.Dependencies,
+	)
+	p.logger.Debug("Downloading custom k6 binary",
+		"url", artifact.URL,
+	)
 	err = p.downloader.download(ctx, artifact.URL, binPath, artifact.Checksum)
 	if err != nil {
 		_ = os.RemoveAll(artifactDir) //nolint:forbidigo
 		return K6Binary{}, NewWrappedError(ErrDownload, err)
 	}
+
+	p.logger.Info("Custom k6 binary ready",
+		"path", binPath,
+		"artifact_id", artifact.ID,
+		"deps", artifact.Dependencies,
+	)
 
 	// start pruning in background
 	// TODO: handle case the calling process is cancelled

--- a/pruner.go
+++ b/pruner.go
@@ -3,6 +3,8 @@ package k6provider
 import (
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,7 +12,7 @@ import (
 	"time"
 )
 
-// Pruner prunes binaries suing a LRU policy to enforce a limit
+// Pruner prunes binaries using a LRU policy to enforce a limit
 // defined in a high-water-mark.
 type Pruner struct {
 	pruneLock     sync.Mutex
@@ -19,6 +21,7 @@ type Pruner struct {
 	hwm           int64
 	pruneInterval time.Duration
 	lastPrune     time.Time
+	logger        *slog.Logger
 }
 
 type pruneTarget struct {
@@ -30,11 +33,21 @@ type pruneTarget struct {
 // NewPruner creates a [Pruner] given its high-water-mark limit, and the
 // prune interval
 func NewPruner(dir string, hwm int64, pruneInterval time.Duration) *Pruner {
+	return NewPrunerWithLogger(dir, hwm, pruneInterval, nil)
+}
+
+// NewPrunerWithLogger creates a [Pruner] with the given logger.
+// If logger is nil, a discard logger is used.
+func NewPrunerWithLogger(dir string, hwm int64, pruneInterval time.Duration, logger *slog.Logger) *Pruner {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
 	return &Pruner{
 		dirLock:       newDirLock(dir),
 		dir:           dir,
 		hwm:           hwm,
 		pruneInterval: pruneInterval,
+		logger:        logger,
 	}
 }
 
@@ -45,6 +58,38 @@ func (p *Pruner) Touch(binPath string) {
 		defer p.pruneLock.Unlock()
 		_ = os.Chtimes(binPath, time.Now(), time.Now()) //nolint:forbidigo
 	}
+}
+
+// scanTargets reads the cache directory and returns the list of binaries
+// eligible for pruning together with the total cache size.
+func (p *Pruner) scanTargets() ([]pruneTarget, int64, error) {
+	binaries, err := os.ReadDir(p.dir) //nolint:forbidigo
+	if err != nil {
+		return nil, 0, fmt.Errorf("%w: %w", ErrPruningCache, err)
+	}
+
+	var (
+		cacheSize    int64
+		pruneTargets []pruneTarget
+	)
+	for _, binDir := range binaries {
+		// skip any spurious file, each binary is in a directory
+		if !binDir.IsDir() {
+			continue
+		}
+		binPath := filepath.Join(p.dir, binDir.Name(), k6Binary)
+		binInfo, err := os.Stat(binPath) //nolint:forbidigo
+		if err != nil {
+			continue
+		}
+		cacheSize += binInfo.Size()
+		pruneTargets = append(pruneTargets, pruneTarget{
+			path:      filepath.Dir(binPath), // we are going to prune the directory
+			size:      binInfo.Size(),
+			timestamp: binInfo.ModTime(),
+		})
+	}
+	return pruneTargets, cacheSize, nil
 }
 
 // Prune the cache of least recently used files
@@ -77,50 +122,37 @@ func (p *Pruner) Prune() error {
 		_ = p.dirLock.unlock()
 	}()
 
-	binaries, err := os.ReadDir(p.dir) //nolint:forbidigo
+	pruneTargets, cacheSize, err := p.scanTargets()
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrPruningCache, err)
-	}
-
-	errs := []error{ErrPruningCache}
-	cacheSize := int64(0)
-	pruneTargets := []pruneTarget{}
-	for _, binDir := range binaries {
-		// skip any spurious file, each binary is in a directory
-		if !binDir.IsDir() {
-			continue
-		}
-
-		binPath := filepath.Join(p.dir, binDir.Name(), k6Binary)
-		binInfo, err := os.Stat(binPath) //nolint:forbidigo
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		cacheSize += binInfo.Size()
-		pruneTargets = append(
-			pruneTargets,
-			pruneTarget{
-				path:      filepath.Dir(binPath), // we are going to prune the directory
-				size:      binInfo.Size(),
-				timestamp: binInfo.ModTime(),
-			})
+		return err
 	}
 
 	if cacheSize <= p.hwm {
 		return nil
 	}
 
+	p.logger.Info("Pruning binary cache",
+		"dir", p.dir,
+		"cache_size", cacheSize,
+		"limit", p.hwm,
+		"entries", len(pruneTargets),
+	)
+
 	sort.Slice(pruneTargets, func(i, j int) bool {
 		return pruneTargets[i].timestamp.Before(pruneTargets[j].timestamp)
 	})
 
+	errs := []error{ErrPruningCache}
 	for _, target := range pruneTargets {
 		if err := os.RemoveAll(target.path); err != nil { //nolint:forbidigo
 			errs = append(errs, err)
 			continue
 		}
 
+		p.logger.Debug("Pruned cached binary",
+			"path", target.path,
+			"size", target.size,
+		)
 		cacheSize -= target.size
 		if cacheSize <= p.hwm {
 			return nil


### PR DESCRIPTION
## Summary

Adds `*slog.Logger` support to `Provider` and `Pruner` so callers can
integrate k6provider's operational events into their own logging
infrastructure (e.g. k6's logrus logger via a thin `slog.Handler` bridge).

### API additions

- `NewProviderWithLogger(config Config, logger *slog.Logger) (*Provider, error)`
- `NewPrunerWithLogger(dir string, hwm int64, pruneInterval time.Duration, logger *slog.Logger) *Pruner`

Both default to a discard logger when `nil` is passed — no behaviour
change for existing callers of `NewProvider` / `NewPruner`.

### What gets logged

| Level | Event |
|-------|-------|
| Info  | `"Downloading custom k6 binary"` — artifact_id, deps |
| Debug | `"Downloading custom k6 binary"` — url |
| Info  | `"Custom k6 binary ready"` — artifact_id, deps, path |
| Info  | `"Using cached k6 binary"` — artifact_id, deps, path |
| Debug | `"Resolving k6 artifact"` — deps, platform |
| Debug | `"Artifact resolved"` — artifact_id, deps, url |
| Info  | `"Pruning binary cache"` — dir, cache_size, limit, entries |
| Debug | `"Pruned cached binary"` — path, size |
| Debug | `"Download retry"` — retries_left, backoff, error |

## Screenshots

**Provisioning a new binary:**

<img width="2090" height="89" alt="image" src="https://github.com/user-attachments/assets/1723d263-5c1b-4ae8-89e3-ababbc87c9ad" />

**Using a cached binary:**

<img width="2105" height="84" alt="image" src="https://github.com/user-attachments/assets/cb1acfa2-3bda-4452-8838-0b395ce0610c" />


It will be nice if this all is one line that gets updated similar to how we do for test run, but that and being in separate libraries seems more convoluted. 

This still improves the actual feedback on what is happening. 

https://github.com/grafana/k6/issues/5525 is related to this and shows the major problem of previously k6 just standing there when it needs to download a binary. 
