### PR TITLE
Expose whether a binary is cached locally

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -365,6 +366,24 @@ func (p *Provider) GetBinary(ctx context.Context, constrains Dependencies) (K6Bi
 		Cached:       false,
 		DownloadURL:  artifact.URL,
 	}, nil
+}
+
+// GetCachedBinary resolves the artifact via the build service, then looks up a cached local binary
+// for the dependencies. If the binary is cached, it returns it with Cached=true and marks it as recently
+// used for pruning. On cache miss it returns [fs.ErrNotExist]. It does not download the binary.
+func (p *Provider) GetCachedBinary(ctx context.Context, constraints Dependencies) (K6Binary, error) {
+	artifact, err := p.GetArtifact(ctx, constraints)
+	if err != nil {
+		return K6Binary{}, err
+	}
+	bin, err := p.resolveBinary(artifact)
+	if err != nil {
+		return K6Binary{}, err
+	}
+	if !bin.Cached {
+		return K6Binary{}, fs.ErrNotExist
+	}
+	return bin, nil
 }
 
 // resolveBinary resolves the local binary for the given artifact. If the binary is

--- a/provider.go
+++ b/provider.go
@@ -321,29 +321,18 @@ func (p *Provider) GetBinary(ctx context.Context, constrains Dependencies) (K6Bi
 	}
 	defer lock.unlock() //nolint:errcheck
 
-	binPath := filepath.Join(artifactDir, k6Binary)
-	_, err = os.Stat(binPath) //nolint:forbidigo
-
-	// binary already exists and is valid
-	if err == nil {
+	bin, err := p.resolveBinary(artifact)
+	if err != nil {
+		return K6Binary{}, err
+	}
+	binPath := bin.Path
+	if bin.Cached {
 		p.logger.Info("Using cached k6 binary",
 			"path", binPath,
 			"artifact_id", artifact.ID,
 			"deps", artifact.Dependencies,
 		)
-		go p.pruner.Touch(binPath)
-
-		return K6Binary{
-			Path:         binPath,
-			Dependencies: artifact.Dependencies,
-			Checksum:     artifact.Checksum,
-			Cached:       true,
-		}, nil
-	}
-
-	// if there's other error)
-	if !os.IsNotExist(err) { //nolint:forbidigo
-		return K6Binary{}, NewWrappedError(ErrBinary, err)
+		return bin, nil
 	}
 
 	p.logger.Info("Downloading custom k6 binary",
@@ -376,6 +365,33 @@ func (p *Provider) GetBinary(ctx context.Context, constrains Dependencies) (K6Bi
 		Cached:       false,
 		DownloadURL:  artifact.URL,
 	}, nil
+}
+
+// resolveBinary resolves the local binary for the given artifact. If the binary is
+// cached, it returns it with Cached=true. Otherwise, it returns a K6Binary whose
+// Path is where the binary should be downloaded. It does not download the binary.
+func (p *Provider) resolveBinary(artifact Artifact) (K6Binary, error) {
+	binPath := filepath.Join(p.binDir, artifact.ID, k6Binary)
+	_, err := os.Stat(binPath) //nolint:forbidigo
+
+	// binary already exists and is valid
+	if err == nil {
+		go p.pruner.Touch(binPath)
+
+		return K6Binary{
+			Path:         binPath,
+			Dependencies: artifact.Dependencies,
+			Checksum:     artifact.Checksum,
+			Cached:       true,
+		}, nil
+	}
+
+	// if there's other error)
+	if !os.IsNotExist(err) { //nolint:forbidigo
+		return K6Binary{}, NewWrappedError(ErrBinary, err)
+	}
+
+	return K6Binary{Path: binPath}, nil
 }
 
 func buildDeps(deps Dependencies) (string, []dependency) {

--- a/provider_test.go
+++ b/provider_test.go
@@ -479,3 +479,33 @@ func Test_Provider_GetCachedBinary(t *testing.T) {
 		if bin.Path != "" {
 			t.Fatalf("expected empty path on cache miss, got %q", bin.Path)
 		}
+	})
+
+	t.Run("cached binary hit", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := NewProvider(Config{
+			BinaryCacheDir:  filepath.Join(t.TempDir(), "provider"),
+			BuildServiceURL: testEnv.BuildServiceURL(),
+		})
+		if err != nil {
+			t.Fatalf("initializing provider %v", err)
+		}
+
+		k6, err := provider.GetBinary(t.Context(), deps)
+		if err != nil {
+			t.Fatalf("GetBinary: %v", err)
+		}
+
+		bin, err := provider.GetCachedBinary(t.Context(), deps)
+		if err != nil {
+			t.Fatalf("GetCachedBinary: %v", err)
+		}
+		if !bin.Cached {
+			t.Fatal("expected cached binary")
+		}
+		if bin.Path != k6.Path {
+			t.Fatalf("expected cached path %s, got %s", k6.Path, bin.Path)
+		}
+	})
+}

--- a/provider_test.go
+++ b/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -451,3 +452,30 @@ func Test_Provider(t *testing.T) { //nolint:tparallel
 		}
 	})
 }
+
+func Test_Provider_GetCachedBinary(t *testing.T) {
+	t.Parallel()
+
+	testEnv := newTestEnv(t)
+	t.Cleanup(testEnv.Cleanup)
+
+	deps := Dependencies{"k6": "=v0.50.0"}
+
+	t.Run("cached binary miss", func(t *testing.T) {
+		t.Parallel()
+
+		provider, err := NewProvider(Config{
+			BinaryCacheDir:  filepath.Join(t.TempDir(), "provider"),
+			BuildServiceURL: testEnv.BuildServiceURL(),
+		})
+		if err != nil {
+			t.Fatalf("initializing provider %v", err)
+		}
+
+		bin, err := provider.GetCachedBinary(t.Context(), deps)
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("expected fs.ErrNotExist on cache miss, got %v", err)
+		}
+		if bin.Path != "" {
+			t.Fatalf("expected empty path on cache miss, got %q", bin.Path)
+		}


### PR DESCRIPTION
## What?

Callers can now get a provisioned binary from the cache (if any) without building it. The build service still needs to be called to resolve deps to an artifact ID. Follow-up design/work can be done to skip calling the build service entirely. But for now, this is good enough to keep the k6 completions for provisioned extensions responsive and quick.

## Why?

k6 shell completions provision a binary and delegate the completion request to it. When the binary isn't cached, this takes ~10 secs without feedback. We need a way to check the cache and skip delegation when the binary isn't there.

## Related

Closes #113