### PR TITLE
feat: add K6ModPath support for k6 v2 build routing

### DIFF
--- a/client.go
+++ b/client.go
@@ -31,6 +31,7 @@ type buildArtifact struct {
 
 // buildRequest defines a request to the build service
 type buildRequest struct {
+	K6ModPath     string       `json:"k6_mod_path,omitempty"`
 	K6Constraints string       `json:"k6,omitempty"`
 	Dependencies  []dependency `json:"dependencies,omitempty"`
 	Platform      string       `json:"platform,omitempty"`
@@ -74,10 +75,12 @@ func newBuildServiceClient(
 func (r *buildClient) Build(
 	ctx context.Context,
 	platform string,
+	k6ModPath string,
 	k6Constraints string,
 	deps []dependency,
 ) (buildArtifact, error) {
 	req := buildRequest{
+		K6ModPath:     k6ModPath,
 		Platform:      platform,
 		K6Constraints: k6Constraints,
 		Dependencies:  deps,

--- a/provider.go
+++ b/provider.go
@@ -21,7 +21,6 @@ import (
 const (
 	k6Module             = "k6"
 	defaultPruneInterval = time.Hour
-
 )
 
 var (

--- a/provider.go
+++ b/provider.go
@@ -21,6 +21,7 @@ import (
 const (
 	k6Module             = "k6"
 	defaultPruneInterval = time.Hour
+
 )
 
 var (
@@ -96,6 +97,10 @@ type Config struct {
 	PruneInterval time.Duration
 	// Download configuration
 	DownloadConfig DownloadConfig
+	// K6ModPath is the Go module path for k6. If empty, k6_mod_path is omitted from
+	// build requests and the build service defaults to go.k6.io/k6 (v1).
+	// Set to "go.k6.io/k6/v2" for k6 v2 builds.
+	K6ModPath string
 }
 
 // Dependencies defines a group of dependencies with their version constrains
@@ -112,6 +117,7 @@ type Provider struct {
 	binDir     string
 	buildSrv   *buildClient
 	platform   string
+	k6ModPath  string
 	pruner     *Pruner
 	logger     *slog.Logger
 }
@@ -210,6 +216,7 @@ func NewProviderWithLogger(config Config, logger *slog.Logger) (*Provider, error
 		binDir:     binDir,
 		buildSrv:   buildSrv,
 		platform:   platform,
+		k6ModPath:  config.K6ModPath,
 		pruner:     pruner,
 		logger:     logger,
 	}, nil
@@ -242,7 +249,7 @@ func (p *Provider) GetArtifact(
 		"deps", deps,
 		"platform", p.platform,
 	)
-	artifact, err := p.buildSrv.Build(ctx, p.platform, k6Constrains, buildDeps)
+	artifact, err := p.buildSrv.Build(ctx, p.platform, p.k6ModPath, k6Constrains, buildDeps)
 	if err != nil {
 		if !errors.Is(err, ErrInvalidParameters) {
 			return Artifact{}, NewWrappedError(ErrBuild, err)


### PR DESCRIPTION
## What

Adds a `K6ModPath` field to `Config` and forwards it as `k6_mod_path` in every build service request. This allows a k6 v2 binary to tell the build service which k6 module to resolve and build against.

## Why

k6build routes build requests to the correct catalog (v1 vs v2) based on the `k6_mod_path` field in the request. Without this field, all requests default to the v1 catalog regardless of which k6 binary is making the request.

## How

- `Config.K6ModPath string` — callers set this to `"go.k6.io/k6/v2"` for v2 builds. Empty string omits the field from the request, and the build service defaults to `go.k6.io/k6` (v1), so existing callers are unaffected.
- `buildRequest.K6ModPath` — new `json:"k6_mod_path,omitempty"` field added to the internal request struct.
- `buildClient.Build` gains a `k6ModPath string` parameter which is set from `Provider.k6ModPath` on every `GetArtifact` call.

## Notes

This PR is part of the k6 v2 build support effort. It is a dependency of the k6 change that sets `K6ModPath: "go.k6.io/k6/v2"` in the provider config, and requires a k6build server updated to accept the `k6_mod_path` field (old servers using `DisallowUnknownFields` will return HTTP 400).