### PR TITLE
ci: use grafana/k6-ci-hosted golangci-lint config

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@40021b94d407d92bff09e4229f102306d68bb7e0 # lint-action branch — bump once grafana/k6-ci#33 merges
+    uses: grafana/k6-ci/.github/workflows/all.yml@1024dc57c16ede322d654963223af198be6a1eda # lint-action branch — bump once grafana/k6-ci#33 merges
     with:
+      k6-ci-ref: 1024dc57c16ede322d654963223af198be6a1eda
       skip-extension-testing: true

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@2e841ed1f99228ce33269efa60e300721ba5d683 # lint-action branch — bump once grafana/k6-ci#33 merges
+    uses: grafana/k6-ci/.github/workflows/all.yml@54cd23cf21e6bb673f131b4de6c05b86b458fd4b # v0.1.0
     with:
-      k6-ci-ref: 2e841ed1f99228ce33269efa60e300721ba5d683
+      k6-ci-ref: 54cd23cf21e6bb673f131b4de6c05b86b458fd4b # v0.1.0
       skip-extension-testing: true

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@72a6e5968a5e94ad268c209630a87f3bdce47c16 # lint-action branch — bump once grafana/k6-ci#33 merges
+    uses: grafana/k6-ci/.github/workflows/all.yml@40021b94d407d92bff09e4229f102306d68bb7e0 # lint-action branch — bump once grafana/k6-ci#33 merges
     with:
       skip-extension-testing: true

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@013dae575c6e433d4b2490c3809559956343d76c # main
+    uses: grafana/k6-ci/.github/workflows/all.yml@72a6e5968a5e94ad268c209630a87f3bdce47c16 # lint-action branch — bump once grafana/k6-ci#33 merges
     with:
       skip-extension-testing: true

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@1024dc57c16ede322d654963223af198be6a1eda # lint-action branch — bump once grafana/k6-ci#33 merges
+    uses: grafana/k6-ci/.github/workflows/all.yml@53e8f37565975ec51374a334cb2d1df1f68b47b6 # lint-action branch — bump once grafana/k6-ci#33 merges
     with:
-      k6-ci-ref: 1024dc57c16ede322d654963223af198be6a1eda
+      k6-ci-ref: 53e8f37565975ec51374a334cb2d1df1f68b47b6
       skip-extension-testing: true

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   checks:
-    uses: grafana/k6-ci/.github/workflows/all.yml@53e8f37565975ec51374a334cb2d1df1f68b47b6 # lint-action branch — bump once grafana/k6-ci#33 merges
+    uses: grafana/k6-ci/.github/workflows/all.yml@2e841ed1f99228ce33269efa60e300721ba5d683 # lint-action branch — bump once grafana/k6-ci#33 merges
     with:
-      k6-ci-ref: 53e8f37565975ec51374a334cb2d1df1f68b47b6
+      k6-ci-ref: 2e841ed1f99228ce33269efa60e300721ba5d683
       skip-extension-testing: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+/build/
+

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,46 @@
-GOLANGCI_CONFIG ?= .golangci.yml
+WORKFLOW   ?= .github/workflows/all.yml
+K6_CI_REF  := $(shell grep -oE 'grafana/k6-ci/[^@[:space:]]+@[A-Za-z0-9._/-]+' $(WORKFLOW) | head -n1 | cut -d@ -f2)
+BASE_URL   := https://raw.githubusercontent.com/grafana/k6-ci/$(K6_CI_REF)/.golangci.yml
+
+LINT_DIR   ?= build/lint
+LINT_BASE  := $(LINT_DIR)/.golangci-base.yml
+LINT_FINAL := $(LINT_DIR)/.golangci.yml
+LINT_PATCH ?= .golangci.patch
 
 all: lint test
 
-## linter-config: Checks if the linter config exists, if not, downloads it from the main k6 repository.
-.PHONY: linter-config
-linter-config:
-	test -s "${GOLANGCI_CONFIG}" || (echo "No linter config, downloading from main k6 repository..." && curl --silent --show-error --fail --no-location https://raw.githubusercontent.com/grafana/k6/master/.golangci.yml --output "${GOLANGCI_CONFIG}")
+$(LINT_DIR):
+	mkdir -p $@
 
-## check-linter-version: Checks if the linter version is the same as the one specified in the linter config.
-.PHONY: check-linter-version
-check-linter-version:
-	(golangci-lint version | grep "version $(shell head -n 1 .golangci.yml | tr -d '\# ')") || echo "Your installation of golangci-lint is different from the one that is specified in k6's linter config (there it's $(shell head -n 1 .golangci.yml | tr -d '\# ')). Results could be different in the CI."
+$(LINT_BASE): $(WORKFLOW) | $(LINT_DIR)
+	curl -fsSL $(BASE_URL) -o $@
 
-## lint: Runs the linters.
+$(LINT_FINAL): $(LINT_BASE) $(wildcard $(LINT_PATCH))
+	cp $(LINT_BASE) $@
+	@if [ -f $(LINT_PATCH) ]; then \
+	  echo "Applying $(LINT_PATCH)"; \
+	  git apply --directory=$(LINT_DIR) $(LINT_PATCH); \
+	fi
+
+## lint: Run golangci-lint with the k6-ci config (and optional .golangci.patch).
 .PHONY: lint
-lint: linter-config check-linter-version
-	echo "Running linters..."
-	golangci-lint run ./...
+lint: $(LINT_FINAL)
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$$(head -n1 $(LINT_BASE) | tr -d '# ') \
+	  run --config=$(LINT_FINAL) ./...
+
+## update-lint-patch: Regenerate .golangci.patch from the locally edited $(LINT_FINAL).
+.PHONY: update-lint-patch
+update-lint-patch: $(LINT_BASE)
+	@if [ ! -f $(LINT_FINAL) ]; then \
+	  echo "Run 'make lint' first to materialize $(LINT_FINAL), edit it, then re-run."; \
+	  exit 1; \
+	fi
+	-diff -u --label a/.golangci.yml --label b/.golangci.yml $(LINT_BASE) $(LINT_FINAL) > $(LINT_PATCH)
+
+## clean-lint: Remove $(LINT_DIR).
+.PHONY: clean-lint
+clean-lint:
+	rm -rf $(LINT_DIR)
 
 .PHONY: test
 test:


### PR DESCRIPTION
## What

- Bump the \`grafana/k6-ci/.github/workflows/all.yml\` pin to the SHA where \`.golangci.yml\` and the new lint action live in k6-ci itself (instead of being fetched from grafana/k6 master on every run).
- Rewrite the local \`Makefile\` to mirror the new flow: read the k6-ci ref from \`.github/workflows/all.yml\`, download the base \`.golangci.yml\` from k6-ci at that ref, optionally apply a \`.golangci.patch\` (none here), run \`golangci-lint\` at the version on line 1. Adds \`update-lint-patch\` and \`clean-lint\` targets for future customization.
- Gitignore \`/build/\` (where the assembled config lives).

## Why

Before this PR, both CI and \`make lint\` got their \`.golangci.yml\` from \`grafana/k6@master\`. Effects:

- Lint behavior changed under k6provider without any change to k6provider whenever k6 master moved.
- No stable pin was possible for the config or the golangci-lint version.

After this PR, the single \`@<ref>\` pin in this workflow drives:

- CI behavior (the reusable workflow downloads the config from k6-ci at that ref)
- Local \`make lint\` (Makefile greps the same ref from the workflow file)
- The golangci-lint version (line 1 of the downloaded config)

Renovate continues to manage the pin.

## Depends on

- grafana/k6-ci#33 — once that merges, bump the pin from the branch SHA to a tagged release SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)