### PR TITLE
chore: align go directive and toolchain to 1.25.0 / 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/k6provider
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.25.11

--- a/provider_test.go
+++ b/provider_test.go
@@ -330,10 +330,7 @@ func Test_Provider(t *testing.T) { //nolint:tparallel
 		errs := make(chan error, 10)
 
 		for range 3 {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-
+			wg.Go(func() {
 				k6, err := provider.GetBinary(context.TODO(), deps)
 				if err != nil {
 					errs <- err
@@ -345,7 +342,7 @@ func Test_Provider(t *testing.T) { //nolint:tparallel
 				if err != nil {
 					errs <- err
 				}
-			}()
+			})
 		}
 
 		wg.Wait()


### PR DESCRIPTION
## Summary
Align `go.mod` to `go 1.25.0` and `toolchain go1.25.11` to match the k6-core baseline.

## Test plan
- [ ] `go mod tidy` is clean
- [ ] CI passes